### PR TITLE
mongoose ^6 upgrade and compatibility fix

### DIFF
--- a/admin/server/api/list/get.js
+++ b/admin/server/api/list/get.js
@@ -30,6 +30,7 @@ module.exports = function (req, res) {
 		assign(where, req.list.addSearchToQuery(req.query.search));
 	}
 	var query = req.list.model.find(where);
+	var countQuery = req.list.model.countDocuments(where);
 	if (req.query.populate) {
 		query.populate(req.query.populate);
 	}
@@ -44,13 +45,12 @@ module.exports = function (req, res) {
 			if (!includeCount) {
 				return next(null, 0);
 			}
-			query.count(next);
+			countQuery.count(next)
 		},
 		function (count, next) {
 			if (!includeResults) {
 				return next(null, count, []);
 			}
-			query.find();
 			query.limit(Number(req.query.limit) || 100);
 			query.skip(Number(req.query.skip) || 0);
 			if (sort.string) {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var grappling = require('grappling-hook');
 var path = require('path');
 var utils = require('keystone-utils');
 var importer = require('./lib/core/importer');
+const legacyPluralize = require('mongoose/lib/helpers/pluralize');
 
 /**
  * Don't use process.cwd() as it breaks module encapsulation
@@ -106,7 +107,7 @@ Keystone.prototype.prefixModel = function (key) {
 		key = modelPrefix + '_' + key;
 	}
 
-	return require('mongoose/lib/utils').toCollectionName(key);
+	return require('mongoose/lib/utils').toCollectionName(key, legacyPluralize);
 };
 
 /* Attach core functionality to Keystone.prototype */

--- a/lib/core/openDatabaseConnection.js
+++ b/lib/core/openDatabaseConnection.js
@@ -31,8 +31,7 @@ module.exports = function openDatabaseConnection (callback) {
 			replset: {
 				rs_name: replicaData.db.replicaSetOptions.rs_name,
 				readPreference: replicaData.db.replicaSetOptions.readPreference,
-			},
-			useMongoClient: true,
+			}
 		};
 
 		debug('connecting to replica set');
@@ -42,7 +41,6 @@ module.exports = function openDatabaseConnection (callback) {
 		debug('connecting to mongo');
 		keystone.initDatabaseConfig();
 		var mongo_options = keystone.get('mongo options') || {};
-		mongo_options.useMongoClient = true;
 		keystone.mongoose.connect(keystone.get('mongo'), mongo_options);
 	}
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "method-override": "^3.0.0",
     "mime-types": "^2.1.24",
     "moment": "^2.24.0",
-    "mongoose": "^4.13.14",
+    "mongoose": "^6.5.0",
     "morgan": "^1.9.1",
     "multer": "^1.4.1",
     "numeral": "^2.0.6",


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes
- package.json, mongoose version to ^6.5.0 (mongoose 7 not used as passing cb has been removed) 
- admin/server/api/list/get.js, used two separate variable for count query and find query ( from mongoose 6 use of same query object more than once in not allowed)
- /lib/core/openDatabaseConnection.js useMongoClient option removed (from mongoose 5)
- index.js, pluralization fn passed to get pluralized prefixed (if any) collection name


## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

